### PR TITLE
Add serial terminal

### DIFF
--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -12,7 +12,8 @@ func TestDefaults(t *testing.T) {
 	assert.Empty(t, cf.Token, "tokens must be empty")
 	assert.Empty(t, cf.DefaultShell, "default shell must be empty")
 	assert.Empty(t, cf.DefaultWorkDir, "default work dir must be empty")
-	assert.NotEmpty(t, cf.BindAddress, "BindAddress should not be empty")
+	assert.Empty(t, cf.BindAddress, "BindAddress should be empty by default")
+	assert.Empty(t, cf.SerialPort, "SerialPort should be empty by default")
 }
 
 func TestTokens(t *testing.T) {
@@ -24,4 +25,21 @@ func TestTokens(t *testing.T) {
 	assert.False(t, cf.CheckToken("wrong"), "empty token must be rejected")
 	assert.True(t, cf.CheckToken("secret"), "valid token must be accepted")
 	assert.True(t, cf.CheckToken("secret2"), "valid token must be accepted")
+}
+
+func TestSanityCheck(t *testing.T) {
+	var cf Config
+	cf.SetDefaults()
+	cf.BindAddress = ""
+	cf.SerialPort = ""
+	assert.Error(t, cf.SanityCheck(), "sanity check must fail with no bind address and no serial port")
+	cf.SerialPort = "/dev/ttyS0:115200"
+	assert.NoError(t, cf.SanityCheck(), "sanity checks should pass with serial port on")
+	cf.SerialPort = ""
+	cf.BindAddress = "127.0.0.1:8421"
+	assert.Error(t, cf.SanityCheck(), "sanity check must fail with bind address and no tokens")
+	cf.Token = []Token{Token{Token: "nots3cr3t"}}
+	assert.NoError(t, cf.SanityCheck(), "sanity checks should pass with webserver on")
+	cf.SerialPort = "/dev/ttyS0:115200"
+	assert.NoError(t, cf.SanityCheck(), "sanity checks should pass with webserver and serial port on")
 }

--- a/cmd/agent/serial.go
+++ b/cmd/agent/serial.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strconv"
+	"strings"
+
+	sr "go.bug.st/serial"
+)
+
+type Reply struct {
+	Command    string `json:"cmd"`     // Command that was executed
+	Shell      string `json:"shell"`   // Optional shell in which the command was executed
+	Runtime    int64  `json:"runtime"` // Command runtime
+	ReturnCode int    `json:"ret"`     // Return code
+	StdOut     string `json:"stdout"`  // Standard output
+	StdErr     string `json:"stderr"`  // Standard error
+}
+
+// Parse the given serial port argument into port and mode
+// Acceptable input is e.g. 'COM1,9600,None,8,one' or '/dev/ttyS0,115200,0,8,1'
+func parseSerialPort(port string) (string, *sr.Mode, error) {
+	var err error
+
+	// Default settings
+	mode := sr.Mode{
+		BaudRate: 115200,
+		Parity:   sr.NoParity,
+		DataBits: 8,
+		StopBits: sr.OneStopBit,
+	}
+
+	// Parse possible options
+	if i := strings.Index(port, ":"); i >= 0 {
+		if i == 0 {
+			return port, &mode, fmt.Errorf("missing serial port")
+		}
+		// Missing arguments. Ignore but still crop the separator
+		if i >= len(port)-1 {
+			port = port[:i]
+		} else {
+			// Split options and port
+			options := strings.Split(port[i+1:], ",")
+			port = port[:i]
+
+			// PORT,[BAUD,PARITY,DATABITS,STOPBITS]
+
+			// Parse arguments. All arguments are optional
+			if options[0] != "" { // Baud
+				mode.BaudRate, err = strconv.Atoi(options[0])
+				if err != nil {
+					return port, &mode, fmt.Errorf("invalid baud rate: %s", err)
+				}
+			}
+			if len(options) > 1 && options[1] != "" { // Parity
+				switch strings.ToLower(options[1]) {
+				case "no", "none":
+					mode.Parity = sr.NoParity
+				case "even":
+					mode.Parity = sr.EvenParity
+				case "odd":
+					mode.Parity = sr.OddParity
+				case "mark":
+					mode.Parity = sr.MarkParity
+				case "space":
+					mode.Parity = sr.SpaceParity
+				default:
+					return port, &mode, fmt.Errorf("invalid parity: %s", err)
+				}
+			}
+			if len(options) > 2 && options[2] != "" { // Databits
+				mode.DataBits, err = strconv.Atoi(options[2])
+				if err != nil {
+					return port, &mode, fmt.Errorf("invalid databits: %s", err)
+				}
+			}
+			if len(options) > 3 && options[3] != "" { // Stop bits
+				switch strings.ToLower(options[3]) {
+				case "1", "one":
+					mode.StopBits = sr.OneStopBit
+				case "1.5", "onepointfive":
+					mode.StopBits = sr.OnePointFiveStopBits
+				case "2", "two":
+					mode.StopBits = sr.TwoStopBits
+				default:
+					return port, &mode, fmt.Errorf("invalid stop bits: %s", err)
+				}
+			}
+
+		}
+	}
+	return port, &mode, nil
+}
+
+// RunSerialTerminalAgent runs the agent against a given serial port. Returns and error if occuring while connecting to the port
+func RunSerialTerminalAgent(dest string, conf Config) error {
+	// Default settings
+	port, mode, err := parseSerialPort(dest)
+	if err != nil {
+		return err
+	}
+	serial, err := sr.Open(port, mode)
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer serial.Close()
+		if err := runSerialTerminalAgent(serial, conf); err != nil {
+			log.Fatalf("serial port error: %s", err)
+		}
+	}()
+	return nil
+}
+
+// Reads from the given stream and will execute all commands.
+func runSerialTerminalAgent(stream io.ReadWriter, conf Config) error {
+	scanner := bufio.NewScanner(stream)
+	for scanner.Scan() {
+		command := strings.TrimSpace(scanner.Text())
+		if command == "" || len(command) < 1 {
+			continue
+		}
+		if command[0] == ':' {
+			// Reserved for special commands, not used currently
+			continue
+		}
+
+		// By design, each command will get it's own fresh struct. This is to avoid possible carry-over of some properties.
+		var job ExecJob
+		job.SetDefaults()
+		job.Shell = conf.DefaultShell
+		job.WorkDir = conf.DefaultWorkDir
+		job.Command = command
+		job.Timeout = 60
+
+		err := job.exec()
+
+		var reply Reply
+		reply.Command = command
+		reply.Shell = job.Shell
+		reply.Runtime = job.runtime
+		reply.ReturnCode = job.ret
+		reply.StdOut = string(job.stdout)
+		reply.StdErr = string(job.stderr)
+		if err != nil {
+			if errors.Is(err, TimeoutError) {
+				reply.ReturnCode = 124
+			} else {
+				log.Fatalf("execution of '%s' failed: %s", command, err)
+				reply.ReturnCode = -1
+			}
+		}
+
+		log.Printf("serial command: '%s' -> %d", command, reply.ReturnCode)
+		if buf, err := json.Marshal(reply); err != nil {
+			return err
+		} else {
+			if _, err := stream.Write(buf); err != nil {
+				return err
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/agent/serial_test.go
+++ b/cmd/agent/serial_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sr "go.bug.st/serial"
+)
+
+type TerminalEmulator struct {
+	in  *bytes.Buffer // Input buffer
+	out *bytes.Buffer // Output buffer
+}
+
+func (term *TerminalEmulator) Read(buf []byte) (int, error) {
+	return term.in.Read(buf)
+}
+
+func (term *TerminalEmulator) Write(buf []byte) (int, error) {
+	return term.out.Write(buf)
+}
+
+func (term *TerminalEmulator) Clear() {
+	term.in.Reset()
+	term.out.Reset()
+}
+
+func NewTerminalEmulator() TerminalEmulator {
+	var term TerminalEmulator
+	term.in = bytes.NewBuffer(nil)
+	term.out = bytes.NewBuffer(nil)
+	return term
+}
+
+func TestSerialTerminal(t *testing.T) {
+	var conf Config
+	var reply Reply
+	terminal := NewTerminalEmulator()
+	decoder := json.NewDecoder(terminal.out)
+
+	conf.DefaultShell = "bash"
+	conf.DefaultWorkDir = ""
+
+	// Run single command
+	terminal.in.Write([]byte("true\n"))
+	runSerialTerminalAgent(&terminal, conf)
+	assert.NoError(t, decoder.Decode(&reply), "reply parsing should succeed")
+	assert.Equal(t, 0, reply.ReturnCode, "return code for `true` should be 0")
+
+	terminal.Clear()
+	decoder = json.NewDecoder(terminal.out)
+
+	// Run multiple commands
+	terminal.in.Write([]byte("! false\n"))
+	terminal.in.Write([]byte("echo 1\n"))
+	terminal.in.Write([]byte("sleep 1\n"))
+	terminal.in.Write([]byte("false\n"))
+	runSerialTerminalAgent(&terminal, conf)
+	assert.NoError(t, decoder.Decode(&reply), "reply parsing should succeed")
+	assert.Equal(t, 0, reply.ReturnCode, "return code for `!false` should be 0")
+	assert.Equal(t, "! false", reply.Command, "command should be `!false`")
+	assert.NoError(t, decoder.Decode(&reply), "reply parsing should succeed")
+	assert.Equal(t, 0, reply.ReturnCode, "return code for `echo 1` should be 0")
+	assert.Equal(t, "echo 1", reply.Command, "command should be `echo 1`")
+	assert.Equal(t, "1\n", reply.StdOut, "command stdout should be `1`")
+	assert.NoError(t, decoder.Decode(&reply), "reply parsing should succeed")
+	assert.Equal(t, 0, reply.ReturnCode, "return code for `sleep 1` should be 0")
+	assert.Equal(t, "sleep 1", reply.Command, "command should be `sleep 1`")
+	assert.GreaterOrEqual(t, reply.Runtime, int64(999), "runtime for `sleep 1` should be >= 1 second")
+	assert.NoError(t, decoder.Decode(&reply), "reply parsing should succeed")
+	assert.NotEqual(t, 0, reply.ReturnCode, "return code for `false` should not be 0")
+	assert.Equal(t, "false", reply.Command, "command should be `false`")
+}
+
+func TestSerialTerminalParsing(t *testing.T) {
+	assertMode := func(mode *sr.Mode, ref *sr.Mode) {
+		assert.Equal(t, ref.BaudRate, mode.BaudRate, "baud rates should match")
+		assert.Equal(t, ref.Parity, mode.Parity, "parity should match")
+		assert.Equal(t, ref.DataBits, mode.DataBits, "data bits should match")
+		assert.Equal(t, ref.StopBits, mode.StopBits, "stop bits should match")
+	}
+
+	// Expected mode. Start with default values
+	defaults := sr.Mode{
+		BaudRate: 115200,
+		Parity:   sr.NoParity,
+		DataBits: 8,
+		StopBits: sr.OneStopBit,
+	}
+	expected := defaults
+
+	// Check default handling for Windows and Linux ports
+	port, mode, err := parseSerialPort("COM1")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("/dev/ttyS0")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "/dev/ttyS0", "/dev/ttyS0 should be parsed as /dev/ttyS0")
+	assertMode(mode, &expected)
+
+	// Check program argument handling. All arguments are optional
+	port, mode, err = parseSerialPort("COM1:9600")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected.BaudRate = 9600
+	assertMode(mode, &expected)
+
+	// Test if all arguments are parsed
+	port, mode, err = parseSerialPort("/dev/ttyS0:57600,even,7,2")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "/dev/ttyS0", "/dev/ttyS0 should be parsed as /dev/ttyS0")
+	expected.BaudRate = 57600
+	expected.Parity = sr.EvenParity
+	expected.DataBits = 7
+	expected.StopBits = sr.TwoStopBits
+	assertMode(mode, &expected)
+
+	// Test Windows-like arguments
+	port, mode, err = parseSerialPort("COM1:9600,None,8,one")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected.BaudRate = 9600
+	expected.Parity = 0
+	expected.DataBits = 8
+	expected.StopBits = sr.OneStopBit
+	assertMode(mode, &expected)
+
+	// Test partial argument parsing
+	port, mode, err = parseSerialPort("COM1:,odd")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.Parity = sr.OddParity
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("COM1:9600,,,")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.BaudRate = 9600
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("COM1:9600,,,two")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.BaudRate = 9600
+	expected.StopBits = 2
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("COM1:,,7")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.DataBits = 7
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("COM1:,,,2")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.StopBits = sr.TwoStopBits
+	assertMode(mode, &expected)
+	port, mode, err = parseSerialPort("COM1:,,,1.5")
+	assert.NoError(t, err, "parseSerialPort should succeed")
+	assert.Equal(t, port, "COM1", "COM1 should be parsed as COM1")
+	expected = defaults
+	expected.StopBits = sr.OnePointFiveStopBits
+	assertMode(mode, &expected)
+
+}

--- a/cmd/agent/www.go
+++ b/cmd/agent/www.go
@@ -57,14 +57,6 @@ func execHandler(cf Config) http.Handler {
 			}
 		}
 
-		// Build reply object
-		type Reply struct {
-			Command    string `json:"cmd"`
-			Runtime    int64  `json:"runtime"`
-			ReturnCode int    `json:"ret"`
-			StdOut     string `json:"stdout"`
-			StdErr     string `json:"stderr"`
-		}
 		var reply Reply
 		reply.Command = job.Command
 		reply.Runtime = job.runtime

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,15 @@ module github.org/grisu48/openqa-agent
 
 go 1.24.0
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/stretchr/testify v1.10.0
+	go.bug.st/serial v1.6.3
+)
 
 require (
+	github.com/creack/goselect v0.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
+github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
+github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.bug.st/serial v1.6.3 h1:S3OG1bH+IDyokVndKrzwxI9ywiGBd8sWOn08dzSqEQI=
+go.bug.st/serial v1.6.3/go.mod h1:nofMJxTeNVny/m6+KaafC6vJGj3miwQZ6vW4BZUGJPI=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Adds functionality for running openqa-agent against a serial terminal. The serial terminal function can be used together or instead of the webserver, but one of either must be present.

Serial terminal works in such a way, that the agent accepts every input and runs each line as it's own command. The result of the executed is then serialized as `Reply` json object back via the serial terminal.