### PR TITLE
Add serialization

### DIFF
--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -30,7 +30,8 @@ type Discovery struct {
 }
 
 type Serial struct {
-	SerialPort string `yaml:"port"` // Serial Port where the agent should run on. Format: DEVICE[:BAUD]
+	SerialPort string `yaml:"port"`       // Serial Port where the agent should run on. Format: DEVICE[:BAUD]
+	Serialized bool   `yaml:"serialized"` // Terminate result object with a \0
 }
 
 // Authentication token object
@@ -49,6 +50,7 @@ func (cf *Config) SetDefaults() {
 	cf.Discovery.DiscoveryAddress = ""
 	cf.Discovery.DiscoveryToken = ""
 	cf.Serial.SerialPort = ""
+	cf.Serial.Serialized = true
 }
 
 // Parse program arguments and apply settings to the config instance

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -14,6 +14,7 @@ func TestDefaults(t *testing.T) {
 	assert.Empty(t, cf.DefaultWorkDir, "default work dir must be empty")
 	assert.Empty(t, cf.Webserver.BindAddress, "BindAddress should be empty by default")
 	assert.Empty(t, cf.Serial.SerialPort, "SerialPort should be empty by default")
+	assert.True(t, cf.Serial.Serialized, "Serialized should be enabled by default")
 }
 
 func TestTokens(t *testing.T) {
@@ -63,4 +64,5 @@ func TestYaml(t *testing.T) {
 	assert.Equal(t, "openqa-agent-1", cf.Discovery.DiscoveryToken)
 	// Serial port
 	assert.Equal(t, "/dev/ttyS0,115200", cf.Serial.SerialPort)
+	assert.True(t, cf.Serial.Serialized)
 }

--- a/cmd/agent/serial.go
+++ b/cmd/agent/serial.go
@@ -163,6 +163,12 @@ func runSerialTerminalAgent(stream io.ReadWriter, conf Config) error {
 			if _, err := stream.Write(buf); err != nil {
 				return err
 			}
+			// Add termination character to mark the end of the json object
+			if conf.Serial.Serialized {
+				if _, err := stream.Write([]byte{0}); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	if err := scanner.Err(); err != nil {

--- a/config.yaml
+++ b/config.yaml
@@ -18,3 +18,4 @@ discovery:
 
 serial:
   port: '/dev/ttyS0,115200'
+  serialized: true


### PR DESCRIPTION
To make it easier for openQA to get the Reply json, we terminate the json object with a \0 character by default. This behaviour can be turned off via a configuration parameter.