### PR TITLE
Use \n as serialization character

### DIFF
--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -31,7 +31,7 @@ type Discovery struct {
 
 type Serial struct {
 	SerialPort string `yaml:"port"`       // Serial Port where the agent should run on. Format: DEVICE[:BAUD]
-	Serialized bool   `yaml:"serialized"` // Terminate result object with a \0
+	Serialized bool   `yaml:"serialized"` // Terminate result object with a \n
 }
 
 // Authentication token object

--- a/cmd/agent/serial.go
+++ b/cmd/agent/serial.go
@@ -199,11 +199,10 @@ func runSerialTerminalAgent(stream io.ReadWriter, conf Config) error {
 			}
 			// Add termination character to mark the end of the json object
 			if conf.Serial.Serialized {
-				if _, err := stream.Write([]byte{0}); err != nil {
+				if _, err := stream.Write([]byte{'\n'}); err != nil {
 					return err
 				}
 			}
 		}
 	}
-	return nil
 }

--- a/cmd/agent/serial_test.go
+++ b/cmd/agent/serial_test.go
@@ -202,7 +202,7 @@ func TestSerialization(t *testing.T) {
 	for range 10 {
 		terminal.in.Write([]byte("true\000"))
 		runSerialTerminalAgent(&terminal, conf)
-		buf, err := terminal.out.ReadBytes(0)
+		buf, err := terminal.out.ReadBytes('\n')
 		assert.NoError(t, err, "reading until termination symbol should succeed")
 		assert.Greater(t, len(buf), 1, "reply buffer should be larger than 1 character")
 		buf = buf[:len(buf)-1] // Remove termination character


### PR DESCRIPTION
Use `\n` as serialization character, as it isn't part of a json object and makes the output more human readable, if needed.